### PR TITLE
feat: mock binary response

### DIFF
--- a/aiohttp_responses/response.py
+++ b/aiohttp_responses/response.py
@@ -5,6 +5,7 @@ import typing as t
 class MockResponse:
     _json: t.Dict[str, t.Any] = None
     _text: str = None
+    _bytes: bytes = None
 
     def __init__(
         self,
@@ -12,6 +13,7 @@ class MockResponse:
         url: str = None,
         json: t.Dict[str, t.Any] = None,
         text: str = None,
+        bytes: bytes = None,
         callback: t.Callable = None,
         attrs: t.Dict[str, t.Any] = None,
     ):
@@ -20,6 +22,7 @@ class MockResponse:
         self._json = json
         self.callback = callback
         self._text = text or jsonlib.dumps(json)
+        self._bytes = bytes or self._text.encode("utf-8")
 
         # Set attrs for flexibility
         attrs = attrs or {}
@@ -36,6 +39,9 @@ class MockResponse:
 
     async def json(self, *args, **kwargs):
         return self._json
+
+    async def read(self):
+        return self._bytes
 
     def release(self):
         pass

--- a/tests/test_aiohttp_responses.py
+++ b/tests/test_aiohttp_responses.py
@@ -30,6 +30,14 @@ async def test_get_request_with_params(aiohttp_responses):
                     await resp.json()
 
 
+async def test_get_request_with_binary_response(aiohttp_responses):
+    with aiohttp_responses as r:
+        r.get("https://host/endpoint").response(bytes=b"123")
+        async with aiohttp.ClientSession() as client:
+            async with client.get("https://host/endpoint") as resp:
+                assert await resp.read() == b"123"
+
+
 async def test_post_request_with_json(aiohttp_responses):
     with aiohttp_responses as r:
         r.post("https://host/endpoint", json={"param": [1, 2]}).response(


### PR DESCRIPTION
Provide support for https://docs.aiohttp.org/en/stable/client_quickstart.html#binary-response-content